### PR TITLE
Corrige preload de index.json

### DIFF
--- a/httpdocs/index.html
+++ b/httpdocs/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="/assets/blog.css?2">
     <link rel="alternate" type="application/feed+json" href="/posts/index.json" />
     <link rel="preload" as="script" href="/assets/blog.js?2" crossorigin>
-    <link rel="preload" as="script" href="/posts/index.json" crossorigin>
+    <link rel="preload" as="fetch" href="/posts/index.json" crossorigin>
     <link rel="icon" type="image/svg+xml" href="/assets/icon.svg">
 
     <title>Jaime Gómez-Obregón</title>


### PR DESCRIPTION
Cambia el atributo `as="script"` por `as="fetch"`.
https://www.w3.org/TR/preload/#as-attribute

Soluciona la alerta que se muestra en el navegador y que se descargue dos veces el archivo `index.json`.
```
[Warning] The resource https://jaime.gomezobregon.com/posts/index.json was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it wasn't preloaded for nothing.
```