### PR TITLE
Corregidas las URLs de links externos en /yo

### DIFF
--- a/httpdocs/pages/yo/index.html
+++ b/httpdocs/pages/yo/index.html
@@ -14,11 +14,11 @@
 
 <p>
     Toda mi vida profesional la he desarrollado en
-    <a href="https//iteisa.com">ITEISA</a>, la empresa que fundé en 2004 y que
+    <a href="https://iteisa.com">ITEISA</a>, la empresa que fundé en 2004 y que
     he dirigido hasta comienzos de 2020. He sido ponente en un montón de
     eventos, profesor universitario y tambíen he ejercido cargos de
     responsabilidad en varias organizaciones empresariales.
-    <a href="https//www.linkedin.com/in/jaimegomezobregon/"
+    <a href="https://www.linkedin.com/in/jaimegomezobregon/"
         >En mi LinkedIn están los detalles</a
     >.
 </p>
@@ -27,10 +27,10 @@
     Ahora me dedico a viajar y a cacharrear con fuentes de datos públicas u
     oficiales, que es una de mis parafilias. Me he propuesto darle un buen meneo
     al sector público utilizando datos y tecnología, y
-    <a href="https//twitter.com/jaimeobregon"
+    <a href="https://twitter.com/jaimeobregon"
         >en mi Twitter voy narrando mi camino</a
     >. También tengo
-    <a href="https//github.com/jaimeobregon/">un espacio en Github</a>, donde
+    <a href="https://github.com/jaimeobregon/">un espacio en Github</a>, donde
     publico algunos de mis proyectos de software.
 </p>
 
@@ -41,12 +41,10 @@
 
 <p>
     El
-    <a href="https//github.com/jaimeobregon/jaime.gomezobregon.com"
-        >código fuente de este sitio</a
-    >
+    <a href="https://github.com/jaimeobregon/jaime.gomezobregon.com">código fuente de este sitio</a>
     es libre bajo licencia AGPL 3.0, y los contenidos que aquí publico tienen
     licencia
-    <a href="https//creativecommons.org/licenses/by-sa/4.0/deed.es"
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.es"
         >CC BY-SA 4.0</a
     >.
 </p>


### PR DESCRIPTION
Actualmente en la web, en /yo, los links externos no funcionan. El problema es que en el html de esa página falta el signo ":" en los href de los enlaces.